### PR TITLE
Fix: Correct typo in the name of the binary in service block

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,25 @@
 These formulae provide software either written by me, or tap'd by me. Use at
 your own discretion.
 
-How do I install these formulae?
+## How do I install these formulae?
 --------------------------------
+
+### Using taps (recommended way)
 Just `brew tap raggi/ale` and then `brew install <formula>`.
 
 If the formula conflicts with one from mxcl/master or another tap, you can `brew install raggi/ale/<formula>`.
 
-You can also install via URL:
+
+### Downloading the formula and manually installing (Alternate)
+You can also download the formula and directly install it:
+
+```
+wget https://raw.github.com/raggi/ale/master/openssl-osx-ca.rb
+brew install --HEAD -s ./openssl-osx-ca.rb
+```
+
+### Directly installing from URL (Not recommended and only for older versions of homebrew)
+If you have older versions of brew, you can try directly installing from a URL:
 
 ```
 brew install https://raw.github.com/raggi/ale/master/<formula>.rb

--- a/openssl-osx-ca.rb
+++ b/openssl-osx-ca.rb
@@ -24,7 +24,7 @@ class OpensslOsxCa < Formula
   end
 
   service do
-    run [bin/"openssl-ox-ca", "#{HOMEBREW_PREFIX}/bin/brew"]
+    run [bin/"openssl-osx-ca", "#{HOMEBREW_PREFIX}/bin/brew"]
     run_type :interval
     interval 3600
     keep_alive true


### PR DESCRIPTION
When the homebrew formula was updated to auto-generate the `service`
block to support `brew services` (see
`8faa5a029f3ca07eb651e6058bb6374d8dfc680d`), there was a small typo in
the binary.

The binary should be `openssl-osx-ca`, not `openssl-ox-ca`. As a result,
whenever anyone tried to run `brew services start openssl-osx-ca`, it
would silently fail.

This corrects that.