### PR TITLE
Fix: Explicitly pass path to cert.pem in service definition

### DIFF
--- a/openssl-osx-ca.rb
+++ b/openssl-osx-ca.rb
@@ -24,7 +24,7 @@ class OpensslOsxCa < Formula
   end
 
   service do
-    run [bin/"openssl-osx-ca", "#{HOMEBREW_PREFIX}/bin/brew"]
+    run [bin/"openssl-osx-ca", "-path", "#{HOMEBREW_PREFIX}/bin/osx-ca-certs", "#{HOMEBREW_PREFIX}/bin/brew"]
     run_type :interval
     interval 3600
     keep_alive true


### PR DESCRIPTION
It seems that when we switched from a plist definition to a service
defintion block to be in line with homebrew's recommendations, we never
explicitly provided the path to the `cert.pem` file generated from the
keychain to the underlying binary `osx-ca-certs`.

The result was that an empty `cert.pem` was generated and used for
openssl. This....predictably broke configs.

All credit goes to @akelge for this fix as she did all the legwork :)

This should close: https://github.com/raggi/openssl-osx-ca/issues/27