### PR TITLE
Fix service definition

### DIFF
--- a/openssl-osx-ca.rb
+++ b/openssl-osx-ca.rb
@@ -24,7 +24,7 @@ class OpensslOsxCa < Formula
   end
 
   service do
-    run [bin/"openssl-osx-ca", "#{HOMEBREW_PREFIX}/bin/brew"]
+    run [bin/"openssl-osx-ca", "-path", opt_bin/"osx-ca-certs", "#{HOMEBREW_PREFIX}/bin/brew"]
     run_type :interval
     interval 3600
     keep_alive true


### PR DESCRIPTION
The service definition doesn't include the path argument to find osx-ca-certs. We need to use this argument as here: https://github.com/raggi/openssl-osx-ca/blob/master/Makefile#L6 and https://github.com/raggi/openssl-osx-ca/blob/master/Library/LaunchAgents/org.ra66i.openssl-osx-ca.plist#L11 in the Brew service definition, otherwise the service will actually wipe out the certificates with a blank file